### PR TITLE
wip(orswot): initial implementation

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -6,6 +6,7 @@ on:
       - '**'
     branches:
       - main
+  pull_request:
 
 env:
   BUILD_TYPE: Debug
@@ -46,4 +47,4 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       shell: bash
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C $BUILD_TYPE --output-on-failure

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -31,18 +31,18 @@ struct read_context {
                const T &val)
       : add_vector(add), remove_vector(rm), value(val) {}
 
-  auto derive_add_context(A a) -> add_context<A> {
+  auto derive_add_context(A a) const noexcept -> add_context<A> {
     auto ret = add_vector;
     auto d = ret.inc(a);
     ret.apply(d);
     return add_context<A>{std::move(ret), std::move(d)};
   }
 
-  auto derive_remove_context() -> remove_context<A> {
+  auto derive_remove_context() const noexcept -> remove_context<A> {
     return remove_context<A>{remove_vector};
   }
 
-  auto split() {
+  auto split() const noexcept {
     return std::pair{value, read_context{add_vector, remove_vector}};
   }
 };

--- a/include/crdt_traits.hpp
+++ b/include/crdt_traits.hpp
@@ -26,7 +26,7 @@ concept cvrdt = requires(T a, T b) {
 
 template <typename T, typename Op>
 concept cmrdt = requires(T a, Op op) {
-    { a.validate_op(op) };
+    { a.validate_op(op) } -> std::convertible_to<std::optional<std::error_condition>>;
     { a.apply(op) };
 };
 
@@ -38,5 +38,8 @@ concept reset_removable = std::is_same_v<V, version_vector<A>> && requires(T t, 
 };
 
 } // namespace crdt.
+
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 #endif // CRDT_TRAITS_H

--- a/include/dot.hpp
+++ b/include/dot.hpp
@@ -18,7 +18,7 @@ template <actor_type A> struct dot {
   dot(dot &dot) = delete;
   auto operator<=>(const dot<A> &b) const = default;
 
-  auto clone() -> dot<A> { return ++(*this); };
+  auto clone() const noexcept -> dot<A> { return ++(*this); };
 };
 
 template <actor_type A> auto operator++(const dot<A> &a) noexcept -> dot<A> {

--- a/include/gcounter.hpp
+++ b/include/gcounter.hpp
@@ -24,21 +24,23 @@ template <actor_type A> struct gcounter {
 
   auto operator<=>(const gcounter<A> &) const noexcept = default;
 
-  auto validate_op(const dot<A> &Op) noexcept
+  auto validate_op(const dot<A> &Op) const noexcept
       -> std::optional<std::error_condition> {
     return std::nullopt;
   }
 
   void apply(const dot<A> &Op) noexcept { inner.apply(Op); }
 
-  auto validate_merge(const version_vector<A> &) noexcept
+  auto validate_merge(const version_vector<A> &) const noexcept
       -> std::optional<std::error_condition> {
     return std::nullopt;
   }
 
   void merge(const gcounter<A> &other) noexcept { inner.merge(other.inner); }
 
-  void reset_remove(const version_vector<A> &v) { inner.reset_remove(v); }
+  void reset_remove(const version_vector<A> &v) noexcept {
+    inner.reset_remove(v);
+  }
 
   auto inc(const A &a, std::uint32_t steps = 1) noexcept -> gcounter<A> {
     auto delta = (*this) + std::pair{a, steps};
@@ -60,7 +62,7 @@ template <actor_type A> struct gcounter {
     return dot(a.first, steps);
   }
 
-  auto read() -> std::uint32_t {
+  auto read() const noexcept -> std::uint32_t {
     return std::accumulate(
         inner.dots.begin(), inner.dots.end(), 0,
         [](std::uint32_t sum, const auto &n) { return sum + n.second; });

--- a/include/gset.hpp
+++ b/include/gset.hpp
@@ -17,7 +17,7 @@ template <value_type T> struct gset {
 
   auto operator<=>(const gset<T> &) const noexcept = default;
 
-  auto validate_merge(const gset<T> &) noexcept
+  auto validate_merge(const gset<T> &) const noexcept
       -> std::optional<std::error_condition> {
     return std::nullopt;
   }
@@ -26,7 +26,7 @@ template <value_type T> struct gset {
     value.insert(other.value.begin(), other.value.end());
   }
 
-  auto validate_op(const T &val) noexcept
+  auto validate_op(const T &val) const noexcept
       -> std::optional<std::error_condition> {
     return std::nullopt;
   }
@@ -47,9 +47,9 @@ template <value_type T> struct gset {
     return res;
   }
 
-  bool contains(const T &val) noexcept { return value.contains(val); }
+  bool contains(const T &val) const noexcept { return value.contains(val); }
 
-  auto read() -> robin_hood::unordered_flat_set<T> { return value; }
+  auto read() const noexcept -> robin_hood::unordered_flat_set<T> { return value; }
 };
 
 } // namespace crdt.

--- a/include/lwwreg.hpp
+++ b/include/lwwreg.hpp
@@ -29,13 +29,14 @@ template <value_type V, marker_type M> struct lwwreg {
     return lwwreg<V, M>{val, m};
   }
 
-  auto validate_update(V &&val, M &&m) -> std::optional<std::error_condition> {
+  auto validate_update(V &&val, M &&m) const noexcept
+      -> std::optional<std::error_condition> {
     if (marker == m && value != val)
       return std::make_error_condition(std::errc::operation_would_block);
     return std::nullopt;
   }
 
-  auto validate_op(lwwreg<V, M> other) noexcept
+  auto validate_op(lwwreg<V, M> other) const noexcept
       -> std::optional<std::error_condition> {
     return valida_update(other.value, other.marker);
   }
@@ -44,7 +45,7 @@ template <value_type V, marker_type M> struct lwwreg {
     update(other.value, other.marker);
   }
 
-  auto validate_merge(lwwreg<V, M> other) noexcept
+  auto validate_merge(lwwreg<V, M> other) const noexcept
       -> std::optional<std::error_condition> {
     return valida_update(other.value, other.marker);
   }

--- a/include/mvreg.hpp
+++ b/include/mvreg.hpp
@@ -26,11 +26,12 @@ template <actor_type A, value_type T> struct mvreg {
   };
   std::vector<value> vals;
 
-  auto operator==(const mvreg<A, T> &other) const -> bool {
+  auto operator==(const mvreg<A, T> &other) const noexcept -> bool {
     const auto cmp_values = [](const std::vector<value> &v1,
                                const std::vector<value> &v2) -> bool {
       for (const auto &d : v1) {
-        if (std::ranges::none_of(v2, [=](const value &v) { return v == d; }))
+        if (std::none_of(v2.begin(), v2.end(),
+                         [=](const value &v) { return v == d; }))
           return false;
       }
       return true;
@@ -38,14 +39,14 @@ template <actor_type A, value_type T> struct mvreg {
     return cmp_values(vals, other.vals) && cmp_values(other.vals, vals);
   }
 
-  void reset_remove(const version_vector<A> &clock) {
+  void reset_remove(const version_vector<A> &clock) noexcept {
     std::erase_if(vals, [clock = &clock](const auto &val) {
       val.vclock.reset_remove(clock);
       return val.vclock.empty();
     });
   }
 
-  auto validate_merge(const mvreg<A, T> &other) noexcept
+  auto validate_merge(const mvreg<A, T> &other) const noexcept
       -> std::optional<std::error_condition> {
     return std::nullopt;
   }
@@ -53,10 +54,10 @@ template <actor_type A, value_type T> struct mvreg {
   void merge(mvreg<A, T> other) noexcept {
     auto erase_filter = [](auto &origin, const auto &filter) {
       std::erase_if(origin, [vals = &filter](const auto &val) {
-        return std::ranges::count_if(*vals,
-                                     [clock = val.vclock](const auto &val) {
-                                       return clock < val.vclock;
-                                     }) != 0;
+        return std::count_if(vals->begin(), vals->end(),
+                             [clock = val.vclock](const auto &val) {
+                               return clock < val.vclock;
+                             }) != 0;
       });
     };
     erase_filter(vals, other.vals);
@@ -64,15 +65,16 @@ template <actor_type A, value_type T> struct mvreg {
     vals.insert(vals.end(), other.vals.begin(), other.vals.end());
   }
 
-  auto validate_op(const value &_) noexcept
+  auto validate_op(const value &_) const noexcept
       -> std::optional<std::error_condition> {
     return std::nullopt;
   }
 
   void apply(const value &op) noexcept {
-    if (std::ranges::none_of(vals, [clock = op.vclock](const auto &val) {
-          return val.vclock > clock;
-        }))
+    if (std::none_of(vals.begin(), vals.end(),
+                     [clock = op.vclock](const auto &val) {
+                       return val.vclock > clock;
+                     }))
       vals.push_back(op);
   }
 
@@ -80,25 +82,25 @@ template <actor_type A, value_type T> struct mvreg {
     return value{ctx.vector, val};
   }
 
-  auto write(const A &actor, const T &val) noexcept -> mvreg<A, T> {
+  auto write(const A &actor, const T &val) const noexcept -> mvreg<A, T> {
     mvreg<A, T> reg;
     reg.apply(reg.write(read().derive_add_context(actor), val));
     return mvreg<A, T>{};
   }
 
-  auto read() -> read_context<std::vector<T>, A> {
+  auto read() const noexcept -> read_context<std::vector<T>, A> {
     auto read_ctx = this->read_ctx();
-    std::ranges::transform(vals, std::back_inserter(read_ctx.value),
-                           [](const auto &val) { return val.val; });
+    std::transform(vals.begin(), vals.end(), std::back_inserter(read_ctx.value),
+                   [](const auto &val) { return val.val; });
     return read_ctx;
   }
 
-  auto read_ctx() -> read_context<std::vector<T>, A> {
+  auto read_ctx() const noexcept -> read_context<std::vector<T>, A> {
     auto clock = this->clock();
     return read_context<std::vector<T>, A>(clock, clock, std::vector<T>{});
   }
 
-  auto clock() -> version_vector<A> {
+  auto clock() const noexcept -> version_vector<A> {
     version_vector<A> resutl{};
     for (const auto &val : vals)
       resutl.merge(val.vclock);

--- a/include/orswot.hpp
+++ b/include/orswot.hpp
@@ -1,0 +1,207 @@
+#ifndef ORSWOT_H
+#define ORSWOT_H
+
+#include <algorithm>
+#include <compare>
+#include <iterator>
+#include <optional>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <robin_hood.h>
+
+#include <context.hpp>
+#include <crdt_traits.hpp>
+#include <dot.hpp>
+#include <version_vector.hpp>
+
+namespace crdt {
+
+namespace ops {
+
+template <actor_type M, actor_type A> struct Add {
+  dot<A> d;
+  std::vector<M> members;
+};
+
+template <actor_type M, actor_type A> struct Rm {
+  version_vector<A> clock;
+  std::vector<M> members;
+};
+
+} // namespace ops
+
+template <actor_type M, actor_type A> struct orswot {
+  using vector_clock = version_vector<A>;
+  using deferred_set = robin_hood::unordered_flat_set<M>;
+
+  vector_clock clock;
+  robin_hood::unordered_flat_map<M, vector_clock> entries;
+  robin_hood::unordered_flat_map<vector_clock, deferred_set> deferred;
+
+  orswot() = default;
+  orswot(const orswot<M, A> &) = default;
+  orswot(orswot<M, A> &&) = default;
+
+  auto operator==(const orswot<M, A> &other) const noexcept -> bool {
+    for (const auto &e : other.entries)
+      if (!entries.contains(e.first)) {
+        return false;
+      }
+    for (const auto &e : entries)
+      if (!other.entries.contains(e.first)) {
+        return false;
+      }
+    return true;
+  }
+
+  using Op = std::variant<ops::Add<M, A>, ops::Rm<M, A>>;
+
+  auto validate_op(const Op &op) const noexcept
+      -> std::optional<std::error_condition> {
+    return std::visit(overloaded{
+                          [this](ops::Add<M, A> add) {
+                            return this->clock.validate_op(add.d);
+                          },
+                          [](ops::Rm<M, A>) { return std::nullopt; },
+                      },
+                      op);
+  }
+
+  void apply(const Op &op) noexcept {
+    std::visit(overloaded{
+                   [this](const ops::Add<M, A> &add) {
+                     if (clock.get(add.d.actor) >= add.d.counter) {
+                       return;
+                     }
+
+                     for (const auto &member : add.members) {
+                       auto member_vclock = this->entries[member];
+                       member_vclock.apply(add.d);
+                       this->entries[member] = member_vclock;
+                     }
+
+                     clock.apply(add.d);
+                     this->apply_deferred();
+                   },
+                   [this](const ops::Rm<M, A> &rm) {
+                     apply_rm(
+                         deferred_set(rm.members.begin(), rm.members.end()),
+                         rm.clock);
+                   },
+               },
+               op);
+  }
+
+  void apply_deferred() {
+    for (auto [vclock, entrs] : deferred) {
+      apply_rm(entrs, vclock);
+    }
+  }
+
+  void apply_rm(deferred_set members, vector_clock vclock) {
+    for (const auto &member : members) {
+      if (const auto &member_clock = entries.find(member);
+          member_clock != entries.end()) {
+        member_clock->second.reset_remove(vclock);
+
+        if (member_clock->second.empty())
+          entries.erase(member_clock);
+      }
+    }
+
+    if (auto cmp = vclock <=> this->clock;
+        cmp == std::partial_ordering::greater ||
+        cmp == std::partial_ordering::unordered) {
+      if (auto existing_deferred = deferred.find(vclock);
+          existing_deferred != deferred.end()) {
+        existing_deferred->second.insert(members.begin(), members.end());
+      } else {
+        deferred[vclock] = members;
+      }
+    }
+  }
+
+  void merge(const orswot<M, A> &other) {
+    for (auto it = entries.begin(); it != entries.end();) {
+      if (!other.entries.contains(it->first)) {
+        if (other.clock >= it->second) {
+          it = entries.erase(it);
+        } else {
+          it->second.reset_remove(other.clock);
+          ++it;
+        }
+      } else {
+        ++it;
+      }
+    }
+
+    for (auto [entry, vclock] : other.entries) {
+      if (auto our_clock = entries.find(entry); our_clock != entries.end()) {
+        auto common = intersection(vclock, our_clock->second);
+        common.merge(vclock.clone_without(this->clock));
+        common.merge(our_clock->second.clone_without(other.clock));
+        if (common.empty()) {
+          entries.erase(entry);
+        } else {
+          our_clock->second = common;
+        }
+      } else {
+        if (this->clock >= vclock) {
+        } else {
+          vclock.reset_remove(this->clock);
+          entries[entry] = vclock;
+        }
+      }
+    }
+
+    for (auto [rm_clock, members] : other.deferred)
+      this->apply_rm(members, rm_clock);
+
+    this->clock.merge(other.clock);
+    apply_deferred();
+  }
+
+  auto contains(const M &member) noexcept -> read_context<bool, A> {
+    return read_context(clock, entries[member], entries.contains(member));
+  }
+
+  auto read() const noexcept -> read_context<deferred_set, A> {
+    deferred_set val;
+    std::transform(entries.begin(), entries.end(),
+                   std::inserter(val, val.begin()),
+                   [](auto pair) { return pair.first; });
+    return read_context(clock, clock, val);
+  }
+
+  auto read_ctx() const noexcept -> read_context<deferred_set, A> {
+    return read_context(clock, clock, deferred_set());
+  }
+
+  auto add(add_context<A> ctx, M member) noexcept -> Op {
+    return ops::Add<M, A>{std::move(ctx.dot), {member}};
+  }
+
+  auto add(const A &actor, const M &member) noexcept -> orswot<M, A> {
+    orswot<M, A> delta;
+    delta.apply(delta.add(read_ctx().derive_add_context(actor), member));
+    merge(delta);
+    return delta;
+  }
+
+  auto rm(remove_context<A> ctx, M member) noexcept -> Op {
+    return ops::Rm<M, A>{ctx.vector, {member}};
+  }
+
+  auto rm(const A &_, const M &member) noexcept -> orswot<M, A> {
+    orswot<M, A> delta;
+    delta.apply(delta.rm(read_ctx().derive_remove_context(), member));
+    merge(delta);
+    return delta;
+  }
+};
+
+} // namespace crdt
+
+#endif // ORSWOT_H

--- a/include/pncounter.hpp
+++ b/include/pncounter.hpp
@@ -35,13 +35,14 @@ template <actor_type A> struct pncounter {
     op(dot<A> &&d, Dir &&dir) : Op(std::move(d)), dir(std::move(dir)) {}
   };
 
-  auto validate_op(op Op) noexcept -> std::optional<std::error_condition> {
+  auto validate_op(op Op) const noexcept
+      -> std::optional<std::error_condition> {
     return get_direction(Op.dir).validate_op(Op.Op);
   }
 
   void apply(const op &Op) noexcept { get_direction(Op.dir).apply(Op.Op); }
 
-  auto validate_merge(const pncounter<A> &other) noexcept
+  auto validate_merge(const pncounter<A> &other) const noexcept
       -> std::optional<std::error_condition> {
     auto op = p.validate_merge(other.p);
     if (op == std::nullopt)
@@ -87,7 +88,7 @@ template <actor_type A> struct pncounter {
     return op(n.operator+(std::move(a)), Dir::neg);
   }
 
-  auto read() -> std::uint32_t { return p.read() - n.read(); }
+  auto read() const noexcept -> std::uint32_t { return p.read() - n.read(); }
 
 private:
   gcounter<A> &get_direction(Dir dir) noexcept {

--- a/include/version_vector.hpp
+++ b/include/version_vector.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <compare>
 #include <cstdint>
+#include <iterator>
 #include <numeric>
 #include <robin_hood.h>
 #include <utility>
@@ -25,20 +26,25 @@ template <actor_type A> struct version_vector {
 
   version_vector<A> &operator=(const version_vector<A> &) = default;
   version_vector<A> &operator=(version_vector<A> &&) = default;
+  version_vector<A> &operator=(version_vector<A> &) = default;
 
   auto operator<=>(const version_vector<A> &other) const noexcept {
-    auto cmp_dots = [](const dots_map &a, const dots_map &b) -> bool {
-      return std::ranges::all_of(b, [&a](const auto &d) {
-        const auto [actor, counter] = d;
-        if (const auto &r = a.find(actor); r != a.end() && r->second >= counter)
-          return true;
-        return false;
-      });
+    auto all_gt = [](const version_vector<A> &left,
+                     const version_vector<A> &right) -> bool {
+      return std::all_of(
+          right.dots.begin(), right.dots.end(),
+          [&left](const auto &d) { return left.get(d.first) >= d.second; });
     };
-    if (cmp_dots(dots, other.dots))
+
+    if (this->dots.size() == other.dots.size() &&
+        std::equal(this->dots.begin(), this->dots.end(), other.dots.begin())) {
+      return std::partial_ordering::equivalent;
+    } else if (all_gt(*this, other)) {
       return std::partial_ordering::greater;
-    if (cmp_dots(other.dots, dots))
+    } else if (all_gt(other, *this)) {
       return std::partial_ordering::less;
+    }
+
     return std::partial_ordering::unordered;
   }
 
@@ -53,7 +59,7 @@ template <actor_type A> struct version_vector {
     }
   }
 
-  bool empty() const { return dots.empty(); }
+  bool empty() const noexcept { return dots.empty(); }
 
   auto get(const A &a) const noexcept -> std::uint64_t {
     auto it = dots.find(a);
@@ -70,7 +76,7 @@ template <actor_type A> struct version_vector {
 
   auto inc(const A &a) const noexcept -> dot<A> { return ++get_dot(a); }
 
-  auto validate_op(const dot<A> &Op) noexcept
+  auto validate_op(const dot<A> &Op) const noexcept
       -> std::optional<std::error_condition> {
     auto next_counter = dots.find(Op.actor)->second + 1;
     if (Op.counter > next_counter) {
@@ -86,7 +92,7 @@ template <actor_type A> struct version_vector {
     }
   }
 
-  auto validate_merge(const version_vector<A> &T) noexcept
+  auto validate_merge(const version_vector<A> &T) const noexcept
       -> std::optional<std::error_condition> {
     return std::nullopt;
   }
@@ -95,8 +101,41 @@ template <actor_type A> struct version_vector {
     for (const auto &[actor, counter] : other.dots)
       apply(dot{actor, counter});
   }
+
+  auto clone_without(version_vector<A> base_clock) const noexcept
+      -> version_vector<A> {
+    version_vector<A> cloned(*this);
+    cloned.reset_remove(base_clock);
+    return cloned;
+  }
 };
 
+template <actor_type A>
+auto intersection(const version_vector<A> &left,
+                  const version_vector<A> &right) noexcept
+    -> version_vector<A> {
+  robin_hood::unordered_map<A, std::uint64_t> dots;
+  std::set_intersection(left.dots.begin(), left.dots.end(), right.dots.begin(),
+                        right.dots.end(), std::inserter(dots, dots.begin()));
+  return version_vector(std::move(dots));
+}
+
 } // namespace crdt.
+
+namespace robin_hood {
+
+using namespace crdt;
+
+template <actor_type A> struct hash<version_vector<A>> {
+  size_t operator()(const version_vector<A> &k) const {
+    robin_hood::hash<A> elem_hash;
+    return std::accumulate(k.dots.begin(), k.dots.end(), 0,
+                           [&elem_hash](size_t acc, const auto &elem) {
+                             return acc ^ elem_hash(elem.first);
+                           });
+  }
+};
+
+} // namespace robin_hood
 
 #endif // VERSION_VECTOR_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,3 +25,7 @@ add_test(NAME MVRegTestSuite COMMAND mvreg_test)
 add_executable(gset_test gset_test.cpp)
 target_link_libraries(gset_test crdtxx rapidcheck)
 add_test(NAME GSetTestSuite COMMAND gset_test)
+
+add_executable(orswot_test orswot_test.cpp)
+target_link_libraries(orswot_test crdtxx rapidcheck)
+add_test(NAME ORSWOTTestSuite COMMAND orswot_test)

--- a/tests/orswot_test.cpp
+++ b/tests/orswot_test.cpp
@@ -1,0 +1,240 @@
+#include <algorithm>
+#include <boost/ut.hpp>
+#include <rapidcheck.h>
+
+#include <orswot.hpp>
+#include <utility>
+
+#include "version_vector_utility.hpp"
+
+using set = std::unordered_set<std::string>;
+using replicated_set = crdt::orswot<std::string, std::string>;
+void setup_set(std::string &&ctx, replicated_set &crdt_set, set s) {
+  for (auto &&v : s) {
+    crdt_set.apply(crdt_set.add(crdt_set.read().derive_add_context(ctx), v));
+  }
+};
+
+namespace crdt {
+template <actor_type M, actor_type A>
+void showValue(const orswot<M, A> &v, std::ostream &os) {
+  os << "{ ";
+  os << "clock: [ ";
+  for (const auto &[key, value] : v.clock.dots) {
+    os << "{ " << key << ": " << value << " }, ";
+  }
+  os << " ], entries: { ";
+  for (const auto &[key, value] : v.entries) {
+    os << "{ " << key << ": [ ";
+    for (const auto &[k, v] : value.dots) {
+      os << "{ " << k << ": " << v << " }, ";
+    }
+    os << "] } ";
+  }
+
+  os << " }, deferred: { ";
+  for (const auto &[clock, dset] : v.deferred) {
+    os << "[ [ ";
+    for (const auto &[actor, value] : clock.dots) {
+      os << "{ " << actor << ": " << value << " }, ";
+    }
+    os << " ]: [ ";
+    for (const auto &k : dset) {
+      os << k << ", ";
+    }
+    os << "], ";
+  }
+
+  os << "} }";
+}
+} // namespace crdt
+
+auto main() -> int {
+  using namespace boost::ut;
+  using namespace crdt;
+
+  "ensure deferred merges"_test = [] {
+    replicated_set a;
+    replicated_set b;
+
+    b.apply(b.add(b.read().derive_add_context("A"), "element 1"));
+
+    // remove with a future context.
+    version_vector<std::string> rm;
+    rm.dots["A"] = 4;
+    b.apply(b.rm(remove_context<std::string>{rm}, "element 1"));
+    expect(b.deferred.size() == 1_i);
+
+    a.apply(a.add(a.read().derive_add_context("B"), "element 4"));
+
+    // remove with a future context.
+    version_vector<std::string> rm2;
+    rm2.dots["C"] = 4;
+    b.apply(b.rm(remove_context<std::string>{rm2}, "element 9"));
+    expect(b.deferred.size() == 2_i);
+
+    orswot<std::string, std::string> merged;
+    merged.merge(a);
+    merged.merge(b);
+    merged.merge(orswot<std::string, std::string>());
+    expect(merged.deferred.size() == 2_i);
+  };
+
+  "preserve deferred across merges"_test = [] {
+    orswot<int, std::string> a;
+    orswot<int, std::string> b(a);
+    orswot<int, std::string> c(a);
+
+    a.apply(a.add(a.read().derive_add_context("A"), 5));
+
+    version_vector<std::string> vc;
+    vc.apply(dot<std::string>("A", 3));
+    vc.apply(dot<std::string>("B", 8));
+
+    b.apply(b.rm(remove_context<std::string>{vc}, 5));
+    expect(b.deferred.size() == 1_i);
+
+    c.merge(b);
+    expect(c.deferred.size() == 1_i);
+
+    a.merge(c);
+    expect(a.read().value.empty());
+  };
+
+  "test present but removed"_test = [] {
+    orswot<int, std::string> a;
+    orswot<int, std::string> b;
+
+    a.apply(a.add(a.read().derive_add_context("A"), 1));
+
+    // Replicate it to 'c' so 'a' has 1->{a, 1};
+    auto c(a);
+
+    a.apply(a.rm(a.contains(1).derive_remove_context(), 1));
+
+    b.apply(b.add(b.read().derive_add_context("B"), 1));
+
+    // Replicate 'b' to 'a', so now 'a' has a 1
+    // the one with a Dot of {b, 1} and clock
+    // of [{a, 1}, {b, 1}]
+    a.merge(b);
+
+    b.apply(b.rm(b.contains(1).derive_remove_context(), 1));
+
+    // Both 'c' and 'a' have a '1', but when they merge, there should be
+    // no '1' as 'c's has been removed by 'a' and 'a's has been removed by 'c'.
+    a.merge(b);
+    a.merge(c);
+    expect(a.read().value.empty());
+  };
+
+  "weird highlight 1"_test = [] {
+    orswot<int, std::string> a;
+    orswot<int, std::string> b;
+
+    a.apply(a.add(a.read().derive_add_context("A"), 1));
+    b.apply(b.add(b.read().derive_add_context("A"), 2));
+
+    a.merge(b);
+    expect(a.read().value.empty());
+  };
+
+  "adds dont destroy causality"_test = [] {
+    orswot<int, std::string> a;
+    orswot<int, std::string> b = a;
+    orswot<int, std::string> c = a;
+
+    c.apply(c.add(c.read().derive_add_context("A"), 1));
+    c.apply(c.add(c.read().derive_add_context("B"), 1));
+
+    auto c_elem_ctx = c.contains(1);
+
+    // If we want to remove this entry, the remove context
+    // should descend from vclock { 1->1, 2->1 }
+    expect(c_elem_ctx.remove_vector ==
+           version_vector<std::string>(
+               robin_hood::unordered_map<std::string, std::uint64_t>(
+                   {{"A", 1}, {"B", 1}})));
+
+    a.apply(a.add(a.read().derive_add_context("C"), 1));
+    b.apply(c.rm(c_elem_ctx.derive_remove_context(), 1));
+    a.apply(a.add(a.read().derive_add_context("A"), 1));
+
+    a.merge(b);
+    expect(a.read().value.contains(1));
+  };
+
+  "property based tests"_test = [] {
+    using rc::check;
+
+    expect(check("associative", [](set s1, set s2, set s3) {
+      replicated_set set1;
+      replicated_set set2;
+      replicated_set set3;
+      setup_set("A", set1, s1);
+      setup_set("B", set2, s2);
+      setup_set("C", set3, s3);
+
+      auto set1_snapshot(set1);
+
+      set1.merge(set2);
+      set1.merge(set3);
+
+      set2.merge(set3);
+      set1_snapshot.merge(set2);
+
+      RC_ASSERT(set1 == set1_snapshot);
+    }));
+
+    expect(check("commutative", [](set s1, set s2) {
+      replicated_set set1;
+      replicated_set set2;
+      setup_set("A", set1, s1);
+      setup_set("B", set2, s2);
+
+      auto set1_snapshot(set1);
+
+      set1.merge(set2);
+
+      set2.merge(set1_snapshot);
+
+      RC_ASSERT(set1 == set2);
+    }));
+
+    expect(check("idempotent", [](set s) {
+      replicated_set set;
+      replicated_set set_snapshot;
+      setup_set("A", set, s);
+      setup_set("A", set_snapshot, s);
+
+      set.merge(set_snapshot);
+
+      RC_ASSERT(set == set_snapshot);
+    }));
+
+    expect(rc::check("add change delta", [](set r, std::string value) {
+      replicated_set replica1;
+      setup_set("A", replica1, r);
+      auto replica2(replica1);
+
+      auto delta = replica1.add("A", value);
+
+      replica2.merge(delta);
+
+      RC_ASSERT(replica1 == replica2);
+    }));
+
+    expect(rc::check("remove change delta", [](set r, std::string value) {
+      replicated_set replica1;
+      setup_set("A", replica1, r);
+      auto replica2(replica1);
+
+      auto delta = replica1.rm("A", value);
+
+      replica2.merge(delta);
+
+      RC_ASSERT(replica1 == replica2);
+      RC_ASSERT(replica1.deferred.size() == replica2.deferred.size());
+    }));
+  };
+}


### PR DESCRIPTION
Observed-Remove Set With Out Tombstones implementation based on [riak_dt orswot](https://github.com/basho/riak_dt/blob/develop/src/riak_dt_orswot.erl)

References:
- [Marc Shapiro, Nuno Preguiça, Carlos Baquero, Marek Zawirski (2011) A comprehensive study of Convergent and Commutative Replicated Data Types](http://hal.upmc.fr/inria-00555588/)
- [Annette Bieniusa, Marek Zawirski, Nuno Preguiça, Marc Shapiro, Carlos Baquero, Valter Balegas, Sérgio Duarte (2012) An Optimized Conﬂict-free Replicated Set](http://arxiv.org/abs/1210.3368)
- [Nuno Preguiça, Carlos Baquero, Paulo Sérgio Almeida, Victor Fonte, Ricardo Gonçalves](http://arxiv.org/abs/1011.5808)

Signed-off-by: Maxim Eryomenko <moeryomenko@gmail.com>